### PR TITLE
Update Deprecated Label

### DIFF
--- a/org-mode/srcname
+++ b/org-mode/srcname
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-# name: srcname
+# name: name
 # key: name
 # uuid: name
 # --
-#+srcname: $0
+#+name: $0


### PR DESCRIPTION
As of [Orgmode 7.8](https://orgmode.org/Changes_old.html#org879c9e4) #+srcname has been deprecated and replaced with #+name.