### PR TITLE
fix(org-mode): change deprecated keyword

### DIFF
--- a/org-mode/figure
+++ b/org-mode/figure
@@ -5,4 +5,4 @@
 # --
 #+caption: ${1:caption}
 #+attr_latex: ${2:scale=0.75}
-#+label: fig:${3:label}
+#+name: fig-${3:label}


### PR DESCRIPTION
Change `label` to `name`.

Also substitute colon, which throws a warning with `org-lint`.