### PR TITLE
fix(org-mode): Rename `code` snippet to `begin`

### DIFF
--- a/org-mode/begin
+++ b/org-mode/begin
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: begin
+# key: begin
+# uuid: begin
+# --
+#+begin_${1:type} ${2:options}
+`%`$0
+#+end_$1

--- a/org-mode/code
+++ b/org-mode/code
@@ -1,8 +1,0 @@
-# -*- mode: snippet -*-
-# name: code
-# key: code
-# uuid: code
-# --
-#+begin_${1:lang} ${2:options}
-`%`$0
-#+end_$1


### PR DESCRIPTION
Org now uses `begin_src LANGUAGE`, which is also provided in this package.