### PR TITLE
nit(org-mode): embedded code -> inline code

### DIFF
--- a/org-mode/embedded
+++ b/org-mode/embedded
@@ -1,6 +1,0 @@
-# -*- mode: snippet -*-
-# name: embedded
-# key: emb
-# uuid: emb
-# --
-src_${1:lang}${2:[${3:where}]}{${4:code}}

--- a/org-mode/inline
+++ b/org-mode/inline
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: inline code
+# key: inl
+# uuid: inl
+# --
+src_${1:language}${2:[${3::exports code}]}{${4:code}}


### PR DESCRIPTION
Inline seems to be the better word. I also changed `:where`
to `:exports code`, which is usually required. Also I was confused by
`:where`, and `:exports code` signalizes that this is the inline code
header.