### PR TITLE
simplify org-mode/dot snippet

### DIFF
--- a/org-mode/dot
+++ b/org-mode/dot
@@ -3,8 +3,6 @@
 # key: dot
 # uuid: dot
 # --
-#+begin_src dot :file ${1:file} :cmdline -T${2:pdf} :exports none :results silent
+#+begin_src dot :file ${1:file}.${2:svg} :results file graphics
 `%`$0
 #+end_src
-
-[[file:$1]]


### PR DESCRIPTION
1. ":exports none :results silent" + link to file is pointlessly clunky.
   Just having ":results file graphics" is briefer and even works better.
2. ":cmdline -T${format}" is largely unneeded, as type is selected based
   on the file extension by default, which tends to result in behaviour
3. Change the default format to SVG. Org can be exported to a variety of
   formats, and SVG is more versatile in this respect.