### PR TITLE
fix urls for doomemacs and doomsnippets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ project/framework-specific minor modes available to [Doom Emacs] users.
   ``` emacs-lisp
   (use-package doom-snippets
     :after yasnippet
-    :straight (doom-snippets :type git :host github :repo "hlissner/doom-snippets" :files ("*.el" "*")))
+    :straight (doom-snippets :type git :host github :repo "doomemacs/doom-snippets" :files ("*.el" "*")))
   ``` 
 
 ## Snippets API
@@ -133,4 +133,4 @@ function aliases for your convenience:
 
 
 [yasnippet]: https://github.com/capitaomorte/yasnippet
-[Doom Emacs]: https://github.com/hlissner/doom-emacs
+[Doom Emacs]: https://github.com/doomemacs/doom-emacs


### PR DESCRIPTION
<!--### TLDR; readme links changed to make sense -->

The previous url's were broken, because of the repo owner being hlissner , when it should be doomemacs.


-----
- [X] I searched the issue tracker and this hasn't been PRed before.
- [X] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] I am blindly checking these off.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
