### PR TITLE
fix(nix-mode): drop stdenv.lib, quote urls

### DIFF
--- a/nix-mode/package.github
+++ b/nix-mode/package.github
@@ -3,7 +3,7 @@
 # key: pkgg
 # uuid: pkgg
 # --
-{ stdenv, fetchFromGitHub$1 }:
+{ stdenv, lib, fetchFromGitHub$1 }:
 
 stdenv.mkDerivation rec {
   name = "$2-\$\{version\}";
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "$7";
-    homepage = https://${8:github.com/$4/$2};
+    homepage = "https://${8:github.com/$4/$2}";
 
-    license = stdenv.lib.licenses.${9:$$
+    license = lib.licenses.${9:$$
     (yas-choose-value '(
       "agpl3"
       "asl20"
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
       "lgpl3"
       "mit"
     ))};
-    maintainers = [ stdenv.lib.maintainers.$10 ];
-    platforms = stdenv.lib.platforms.${11:$$
+    maintainers = [ lib.maintainers.$10 ];
+    platforms = lib.platforms.${11:$$
     (yas-choose-value '(
       "gnu"
       "linux"

--- a/nix-mode/package.url
+++ b/nix-mode/package.url
@@ -3,7 +3,7 @@
 # key: pkgu
 # uuid: pkgu
 # --
-{ stdenv, fetchurl$1 }:
+{ stdenv, lib, fetchurl$1 }:
 
 stdenv.mkDerivation rec {
   version = "$2";
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "$6";
-    homepage = https://$7;
-    license = stdenv.lib.licenses.${8:$$
+    homepage = "https://$7";
+    license = lib.licenses.${8:$$
     (yas-choose-value '(
       "agpl3"
       "asl20"
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
       "lgpl3"
       "mit"
     ))};
-    maintainers = [ stdenv.lib.maintainers.$9 ];
-    platforms = stdenv.lib.platforms.${10:$$
+    maintainers = [ lib.maintainers.$9 ];
+    platforms = platforms.${10:$$
     (yas-choose-value '(
       "gnu"
       "linux"


### PR DESCRIPTION
stdenv.lib has been deprecated as well as unquoted urls

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [ ] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
