### PR TITLE
fix(go-mode): Introduces consistent formatting changes to Go snippets

### DIFF
--- a/go-mode/f
+++ b/go-mode/f
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: func ...(...) ... { ... }
 # --
-func ${1:name}(${2:args})${3: return type} {
+func ${1:name}(${2:args}) ${3:return type}{
     `%`$0
 }

--- a/go-mode/func
+++ b/go-mode/func
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: func ...(...) ... { ... }
 # --
-func ${1:name}(${2:args})${3: return type} {
+func ${1:name}(${2:args}) ${3:return type}{
     `%`$0
 }

--- a/go-mode/imp
+++ b/go-mode/imp
@@ -1,4 +1,6 @@
 # -*- mode: snippet -*-
 # name: import
 # --
-import ${1:package}$0
+import (
+    ${1:package}$0
+)

--- a/go-mode/import
+++ b/go-mode/import
@@ -1,4 +1,6 @@
 # -*- mode: snippet -*-
 # name: import
 # --
-import ${1:package}$0
+import (
+    ${1:package}$0
+)

--- a/go-mode/method
+++ b/go-mode/method
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: func (target) name(args) (results) { ... }
 # --
-func (${1:target}) ${2:name}(${3:args})${4: return type} {
+func (${1:target}) ${2:name}(${3:args}) ${4:return type} {
     $0
 }

--- a/go-mode/struct
+++ b/go-mode/struct
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: type ... struct { ... }
 # --
-type $1 struct {
+type ${1:name} struct {
     `%`$0
 }

--- a/go-mode/switch
+++ b/go-mode/switch
@@ -3,7 +3,7 @@
 # key: switch
 # uuid: switch
 # --
-switch {
-    case ${1:cond}:
+switch ${1:express}{
+    case ${2:cond}:
          $0
 }

--- a/go-mode/type
+++ b/go-mode/type
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: type ... ... { ... }
+# --
+type ${1:name} ${2:struct | interface} {
+    `%`$0
+}


### PR DESCRIPTION
**Summary:**

This pull request introduces consistent formatting changes to various Go
code snippets in the 'go-mode' directory. The changes include:

- Adding spaces between function parameters and return types.
- Formatting import statements to use parentheses for multiple imports.
- Updating struct snippets to include a name for the struct type.
- Updating the 'switch' snippet to include an expression.
- Adding `type` for creating a new struct or interface.

**Changes Made:**

- In 'go-mode/f' and 'go-mode/func', added spaces between function
  parameters and return types to follow go convention.

- In 'go-mode/method', added spaces between function parameters and
  return types to follow go convention.

- In 'go-mode/imp' and 'go-mode/import', reformatted import
  statements to use parentheses for multiple imports.

- In 'go-mode/struct', added a name for the struct type for clarity.

- Add a new file `go-mode/type` for creating a new struct or interface.

- In 'go-mode/switch', updated the 'switch' snippet to include an expression for better usage.

These changes improve code readability and maintain consistency throughout the 'go-mode' snippets.

**Related Issues:**
None
<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
