### PR TITLE
snippet(latex): Add `(texmathp)` condition to certain snippets

### DIFF
--- a/latex-mode/bigcap_^
+++ b/latex-mode/bigcap_^
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: bigcap_^
 # key: cap
+# condition: (texmathp)
 # --
 \bigcap${1:$(when (> (length yas-text) 0) "_")
 }${1:$(when (> (length yas-text) 1) "{")

--- a/latex-mode/bigcup_^
+++ b/latex-mode/bigcup_^
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: bigcup_^
 # key: cup
+# condition: (texmathp)
 # --
 \bigcup${1:$(when (> (length yas-text) 0) "_")
 }${1:$(when (> (length yas-text) 1) "{")

--- a/latex-mode/frac
+++ b/latex-mode/frac
@@ -2,5 +2,6 @@
 # name: frac
 # key: frac
 # uuid: frac
+# condition: (texmathp)
 # --
 \frac{${1:`(or % "numerator")`}}{${2:denominator}}$0

--- a/latex-mode/int_^
+++ b/latex-mode/int_^
@@ -1,5 +1,7 @@
+# -*- mode: snippet -*-
 # key: int
 # name: int_^
+# condition: (texmathp)
 # --
 \int${1:$(when (> (length yas-text) 0) "_")
 }${1:$(when (> (length yas-text) 1) "{")

--- a/latex-mode/lim
+++ b/latex-mode/lim
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: lim
 # key: lim
+# condition: (texmathp)
 # --
 \lim_{${1:n} \to ${2:\infty}} $0

--- a/latex-mode/liminf
+++ b/latex-mode/liminf
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: liminf
 # key: liminf
+# condition: (texmathp)
 # --
 \liminf_{${1:n} \to ${2:\infty}} $0

--- a/latex-mode/limsup
+++ b/latex-mode/limsup
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: limsup
 # key: limsup
+# condition: (texmathp)
 # --
 \limsup_{${1:n} \to ${2:\infty}} $0

--- a/latex-mode/prod_^
+++ b/latex-mode/prod_^
@@ -1,5 +1,7 @@
+# -*- mode: snippet -*-
 # key: prod
 # name: prod_^
+# condition: (texmathp)
 # --
 \prod${1:$(when (> (length yas-text) 0) "_")
 }${1:$(when (> (length yas-text) 1) "{")

--- a/latex-mode/root
+++ b/latex-mode/root
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: sqrt[]{}
 # key: root
+# condition: (texmathp)
 # --
 \sqrt[$1]{`%`$2}

--- a/latex-mode/sqrt
+++ b/latex-mode/sqrt
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: sqrt
 # key: sq
+# condition: (texmathp)
 # --
 \sqrt{`%`$1}$0

--- a/latex-mode/sum_^
+++ b/latex-mode/sum_^
@@ -1,5 +1,7 @@
+# -*- mode: snippet -*-
 # key: sum
 # name: sum_^
+# condition: (texmathp)
 # --
 \sum${1:$(when (> (length yas-text) 0) "_")
 }${1:$(when (> (length yas-text) 1) "{")


### PR DESCRIPTION
Fix: #c63094b
- Added `(texmathp)` condition for math specific snippets.
- Added `yasnippet-mode` header for int, sum and prod.
- Removed file-ending newlines.
