### PR TITLE
Search 'using namespace std' should start from the (point-min)

### DIFF
--- a/c++-mode/.yas-setup.el
+++ b/c++-mode/.yas-setup.el
@@ -1,7 +1,7 @@
 (defun doom-snippets-c++-using-std-p ()
   "Return non-nil if 'using namespace std' is found at the top of this file."
   (save-excursion
-    (goto-char (point-max))
+    (goto-char (point-min))
     (or (search-forward "using namespace std;" 512 t)
         (search-forward "std::" 1024 t))))
 


### PR DESCRIPTION
Search 'using namespace std' should start from the `(point-min)`.

<!-- ⚠️ Please do not ignore this template! -->

Replace this with a summary of what you've changed and why, followed by a list of issues it affects, if any.

Fix: #0000
Ref: #0000
Close: #0000

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [ ] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [ ] My changes are visual; I've included before and after screenshots.
- [x] I am blindly checking these off.
- [x] Any relevant issues or PRs have been linked to.
- [ ] This a draft PR; I need more time to finish it.

<!-- Remove checklist items above that don't apply to this PR -->

<!--

 ❤ Thank you for taking the time to contribute! Please be patient while we get
   around to reviewing your PR. 

   - Once a maintainer approves it, there's nothing left to do. It will
     eventually be merged.
   - If we convert your PR to a Draft, it means the verdict is undecided and we
     need more time to think about it.
   - If you decide to close your PR, please let us know why you did so.

-->
