### PR TITLE
Remove extraneous curly brace from cc-mode fori

### DIFF
--- a/cc-mode/fori
+++ b/cc-mode/fori
@@ -3,6 +3,6 @@
 # key: fori
 # uuid: fori
 # --
-for (${1:int} ${2:i} = 0; $2 < ${3:length}; $2++}) {
+for (${1:int} ${2:i} = 0; $2 < ${3:length}; $2++) {
     `%`$0
 }


### PR DESCRIPTION
Should be `for (1; 2; 3) {...}` instead of `for (1; 2; 3}) {...}`.