### PR TITLE
fix(snippets):python-mode:change tryelse key

### DIFF
--- a/python-mode/tryelse
+++ b/python-mode/tryelse
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: tryelse
-# key: try
-# uuid: try
+# key: tryelse
+# uuid: tryelse
 # --
 try:
     $1


### PR DESCRIPTION
This is in line with the `yasnippet-snippets` repo, and prevents the warning "Multiple snippets with same identity"

<!-- ⚠️ Please do not ignore this template! -->

There are two Python snippets with the same key (`try` and `tryelse`), creating a warning. This fixes it, bringing snippets in line with `yasnippet-snippets`.

-----
- [x ] I searched the issue tracker and this hasn't been PRed before.
- [ x] My changes are not on [the do-not-PR list](https://doomemacs.org/donotpr) for this project.
- [ x] My commits conform to [Doom's git conventions](https://doomemacs.org/d/git-conventions).
